### PR TITLE
Renames test to match script for seg 1.11.4

### DIFF
--- a/tests/dao/redis/test_site.py
+++ b/tests/dao/redis/test_site.py
@@ -54,7 +54,7 @@ def test_insert_many(site_dao):
     assert site_dao.find_by_id(3) == site3
 
 
-def test_find_by_id(site_dao):
+def test_find_by_id_existing_site(site_dao):
     site_id = 1
     site = Site(id=site_id,
                 capacity=10.0,


### PR DESCRIPTION
In seg 1.11.4, the test is called `find_by_id_existing_site`, this changes the test in the code to match the script as it's easier than re-recording audio.