### PR TITLE
Use site IDs instead of hash keys in the site IDs set

### DIFF
--- a/tests/dao/redis/test_site.py
+++ b/tests/dao/redis/test_site.py
@@ -70,6 +70,7 @@ def test_find_by_id_existing_site(site_dao):
     assert found_site == site
 
 
+@pytest.mark.skip("Remove for challenge #1")
 def test_find_all(site_dao):
     site1 = Site(id=1,
                  capacity=10.0,


### PR DESCRIPTION
We now advise people to use IDs in containers like Sets, rather than storing keys.