### PR TITLE
Adds expire command for script consistency.

### DIFF
--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,11 +1,15 @@
 
 def test_without_transaction(redis):
     redis.hset("candies:tootsie-rolls", mapping={"flavor": "delicious"})
+    # Expire in 1 hour...
+    redis.expire("candies:tootsie-rolls", 3600)
     redis.sadd("candies", "tootsie-rolls")
 
 
 def test_with_transaction(redis):
     pipeline = redis.pipeline()
     pipeline.hset("candies:tootsie-rolls", mapping={"flavor": "delicious"})
+    # Expire in 1 hour...
+    pipeline.expire("candies:tootsie-rolls", 3600)
     pipeline.sadd("candies", "tootsie-rolls")
     pipeline.execute()


### PR DESCRIPTION
For module 2.7 segment 5 we need an expire command in the tests to match the script.  This adds one for both the transaction and non transaction tests.