### PR TITLE
Use a supplied pipeline for the hset in insert()

### DIFF
--- a/redisolar/dao/redis/site_geo.py
+++ b/redisolar/dao/redis/site_geo.py
@@ -14,8 +14,8 @@ class SiteGeoDaoRedis(SiteGeoDaoBase, RedisDaoBase):
     def insert(self, site: Site, **kwargs):
         """Insert a Site into Redis."""
         hash_key = self.key_schema.site_hash_key(site.id)
-        self.redis.hset(hash_key, mapping=FlatSiteSchema().dump(site))  # type: ignore
         client = kwargs.get('pipeline', self.redis)
+        client.hset(hash_key, mapping=FlatSiteSchema().dump(site))  # type: ignore
 
         if not site.coordinate:
             raise ValueError("Site coordinates are required for Geo insert")


### PR DESCRIPTION
We weren’t using a pipeline inside of this insert() method if one was supplied.