### PR TITLE
Updated to use RedisTimeSeries image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,5 @@ services:
 
   redis:
     container_name: redis
-    image: redis
+    image: redislabs/redistimeseries
     restart: always


### PR DESCRIPTION
This should fix running RedisTimeSeries tests on continuous integration.