### PR TITLE
Implements many trips to Redis find_all version as start point for optional challenge.

### DIFF
--- a/redisolar/dao/redis/site_geo.py
+++ b/redisolar/dao/redis/site_geo.py
@@ -94,13 +94,10 @@ class SiteGeoDaoRedis(SiteGeoDaoBase, RedisDaoBase):
         """Find all Sites."""
         site_ids = self.redis.zrange(self.key_schema.site_geo_key(), 0, -1)
         sites = set()
-        p = self.redis.pipeline(transaction=False)
-        for site_id in site_ids:
-            p.hgetall(self.key_schema.site_hash_key(site_id))
-        site_hashes = p.execute()
 
-        for site_hash in [h for h in site_hashes if h is not None]:
-            site_model = FlatSiteSchema().load(site_hash)
-            sites.add(site_model)
+        for site_id in site_ids:
+            key = self.key_schema.site_hash_key(site_id)
+            site_hash = self.redis.hgetall(key)
+            sites.add(FlatSiteSchema().load(site_hash))
 
         return sites


### PR DESCRIPTION
This gives the student the correct start point for week 3's optional challenge.  Tests pass:

```
$ pytest -k "test_site_geo"
================================================ test session starts =================================================
platform darwin -- Python 3.8.3, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /Users/simon/source/github/ru102py, inifile: pytest.ini
collected 58 items / 49 deselected / 9 selected

tests/api/test_site_geo_api.py ...                                                                             [ 33%]
tests/dao/redis/test_site_geo.py ......                                                                        [100%]

========================================== 9 passed, 49 deselected in 0.45s ==========================================
```