### PR TITLE
Add make target podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ timeseries-docker:
 	docker run -p 6379:6379 -it -d --rm redislabs/redistimeseries
 
 timeseries-podman:
-	podman run -p=127.0.0.1:6379:6379 -it -d --rm redislabs/redistimeseries
+	podman run -p 6379:6379 -it -d --rm redislabs/redistimeseries

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,6 @@ load: env
 
 timeseries-docker:
 	docker run -p 6379:6379 -it -d --rm redislabs/redistimeseries
+
+timeseries-podman:
+	podman run -p=127.0.0.1:6379:6379 -it -d --rm redislabs/redistimeseries

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ To start and run this application, you will need:
 * Access to a local or remote installation of [Redis](https://redis.io/download) version 5 or newer
 * Your Redis installation should have the RedisTimeSeries module installed. You can find the installation instructions at: https://oss.redislabs.com/redistimeseries/#setup
 
-**Note**: If you don't have Redis installed but do have Docker and want to get started quickly,
-run `make timeseries-docker`. This starts a Redis container with RedisTimeSeries installed.
+**Note**: If you don't have Redis installed but do have Docker or Podman and want to get started quickly,
+run `make timeseries-docker` or `make timeseries-podman`. This starts a Redis container with RedisTimeSeries installed.
 
 ### Setting up Python dependencies with make
 


### PR DESCRIPTION
For those who are using Fedora which changed to using [cgroups v2](https://fedoraproject.org/wiki/Changes/CGroupsV2) by default, which Docker does not support yet.

[`podman`](https://podman.io/whatis.html) is a replacement that does support the new cgroups, and it's easily available without having to change kernel flags and a user only has to say `podman` instead of `docker` to get this container (or any container) working.