### PR TITLE
Pin cryptography to avoid rust dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ hiredis==1.0.1
 click==7.1.1
 redistimeseries==0.8.0
 python-dotenv==0.13.0
+cryptography<3.4  # Last version without a Rust dependency


### PR DESCRIPTION
The cryptography package introduced a rust dependency that requires
building with the rust compiler on Alpine Linux.

https://github.com/pyca/cryptography/issues/5771