### PR TITLE
Opened up Makefile to accept newer versions of Python than 3.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,23 @@
 APP := redisolar
 PORT := 8081
-PYTHON3_8 := $(shell command -v python3.8 2> /dev/null)
+VALID_PYTHON_FOUND := $(shell command -v python3.8 2> /dev/null)
+ifndef VALID_PYTHON_FOUND
+    VALID_PYTHON_FOUND := $(shell command -v python3.9 2> /dev/null)
+    PYTHON_COMMAND := "python3.9"
+else
+    PYTHON_COMMAND := "python3.8"
+endif
+ifndef VALID_PYTHON_FOUND
+    VALID_PYTHON_FOUND := $(shell command -v python3.10 2> /dev/null)
+    PYTHON_COMMAND := "python3.10"
+endif
+ifndef VALID_PYTHON_FOUND
+    VALID_PYTHON_FOUND := $(shell command -v python3.11 2> /dev/null)
+    PYTHON_COMMAND := "python3.11"
+endif
 
-ifndef PYTHON3_8
-    $(error "Python 3.8 is not installed! See README.md")
+ifndef VALID_PYTHON_FOUND
+    $(error "Python 3.8-11 is not installed! See README.md")
 endif
 
 ifeq (${IS_CI}, true)
@@ -19,7 +33,7 @@ all: env mypy lint test
 env: env/bin/activate
 
 env/bin/activate: requirements.txt
-	test -d env || python3.8 -m venv env
+	test -d env || ${PYTHON_COMMAND} -m venv env
 	. env/bin/activate; pip install --upgrade pip; pip install pip-tools wheel -e .; pip-sync requirements.txt requirements-dev.txt
 	touch env/bin/activate
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the sample application codebase for the Redis University course [RU102PY
 
 To start and run this application, you will need:
 
-* [Python 3.8](https://www.python.org/downloads/) (**Note**: It must be version 3.8)
+* [Python 3.8 or higher](https://www.python.org/downloads/) (**Note**: It must be version 3.8 or higher)
 * Access to a local or remote installation of [Redis](https://redis.io/download) version 5 or newer
 * Your Redis installation should have the RedisTimeSeries module installed. You can find the installation instructions at: https://oss.redis.com/redistimeseries/#setup
 
@@ -43,6 +43,8 @@ If you want to create a virtualenv manually instead of using `make env`, run the
 following command from the base directory of the project:
 
     python3.8 -m venv env
+
+Substitute `python3.8` for your version of Python if you're running Python 3.9 or 3.10.
 
 #### Dependencies
 


### PR DESCRIPTION
Closes #67 - adds Python 3.9, 3.10 support in Makefile check.

Test run output:

```bash
$ make test
. env/bin/activate; pytest "-s"
============================ test session starts ============================
platform darwin -- Python 3.9.5, pytest-5.4.1, py-1.10.0, pluggy-0.13.1
rootdir: /Users/simonprickett/tmp/ru102py, inifile: pytest.ini
plugins: dotenv-0.5.2
collected 67 items

tests/test_hello.py .
tests/test_quiz_questions.py .......
tests/test_redis_basics.py ....
tests/test_streams.py ...
tests/test_transactions.py ..
tests/api/test_capacity_api.py ..
tests/api/test_meter_reading_api.py ssss
tests/api/test_metrics_api.py sss
tests/api/test_site_api.py .s
tests/api/test_site_geo_api.py ...
tests/dao/redis/test_capacity_report.py ..s
tests/dao/redis/test_feed.py s
tests/dao/redis/test_fixed_rate_limiter.py ..
tests/dao/redis/test_meter_reading.py .
tests/dao/redis/test_metric.py sss
tests/dao/redis/test_metric_timeseries.py ...
tests/dao/redis/test_schema.py ...
tests/dao/redis/test_site.py ....s
tests/dao/redis/test_site_geo.py ......s
tests/dao/redis/test_site_stats.py .
tests/dao/redis/test_sliding_window_rate_limiter.py sss
tests/models/test_models.py ..
tests/scripts/test_update_if_lowest.py ..

====================== 49 passed, 18 skipped in 34.47s ======================
```