### PR TITLE
correct site stats update

### DIFF
--- a/redisolar/dao/redis/site_stats.py
+++ b/redisolar/dao/redis/site_stats.py
@@ -51,7 +51,7 @@ class SiteStatsDaoRedis(SiteStatsDaoBase, RedisDaoBase):
 
         max_capacity = self.redis.hget(key, SiteStats.MAX_CAPACITY)
         if not max_capacity or reading.current_capacity > float(max_capacity):
-            self.redis.hset(key, SiteStats.MAX_CAPACITY, reading.wh_generated)
+            self.redis.hset(key, SiteStats.MAX_CAPACITY, reading.current_capacity)
 
     def _update_optimized(self, key: str, meter_reading: MeterReading,
                           pipeline: redis.client.Pipeline = None) -> None:


### PR DESCRIPTION
Fixes: https://github.com/redislabs-training/ru102py/issues/71

Test `site_stats_dao` was passing because `max_wh_generated` happens to be equal to `max_capacity`, because of reading 2.