### PR TITLE
Override configuration with environment variables if they exist

### DIFF
--- a/redisolar/__init__.py
+++ b/redisolar/__init__.py
@@ -13,6 +13,15 @@ def create_app(config_file=DEV_CONFIG):
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_pyfile(config_file)
 
+    # Override configuration with environment variables if they exist
+    redis_host = os.environ.get('REDIS_HOST')
+    if redis_host:
+        app.config['REDIS_HOST'] = redis_host
+
+    redis_port = os.environ.get('REDIS_PORT')
+    if redis_port:
+        app.config['REDIS_PORT'] = redis_port
+
     app.register_blueprint(api.blueprint)
     api.configure(app)
 


### PR DESCRIPTION
**Override configuration with environment variables if they exist.**

Hey, team. This is your friend Gabs from Harness, and I have a quick suggestion to allow us to provide some important configuration that overrides the config file app.config when necessary.

For example, during my CD Pipeline, I will retrieve the Redis details from a Vault Server, using Harness expressions (`<+secrets.getValue("redis_host")>`) and use it in the K8s Deployment -> Pod -> Container environment variables.

For example, I create a Secret or a Configmap to hold these, but then I serve the variables for the python app at runtime, with K8s's envFrom.



**Small test:**

1-) using a bad redis endpoint, the test will fail:
```
(env) root@DESKTOP-S8EV48S:~/REDIS/REDIS_PYTHON/ru102py# export REDIS_HOST=cerioni.platformengineer.io
(env) root@DESKTOP-S8EV48S:~/REDIS/REDIS_PYTHON/ru102py# pytest ./tests/test_hello.py
FAIL!!!
```

2-) now the good old redis that I have in my godaddy domain:
```
(env) root@DESKTOP-S8EV48S:~/REDIS/REDIS_PYTHON/ru102py# export REDIS_HOST=redis.platformengineer.io
(env) root@DESKTOP-S8EV48S:~/REDIS/REDIS_PYTHON/ru102py# pytest ./tests/test_hello.py
SUCCESS!!!
<...> 1 passed in 2.08s
```

Cheers!